### PR TITLE
Fix crash when decoding RGBA images (OSError: cannot write mode RGBA as JPEG)

### DIFF
--- a/CIS_decoder.py
+++ b/CIS_decoder.py
@@ -1,51 +1,74 @@
 # coding=UTF-8
 # Code Author: Xuzhong Yan
+# Patched: make JPEG saving robust for RGBA/LA/P modes and add error handling.
 
-import sys, io, os, glob, base64, json, ast, random, shutil
+import sys, io, os, base64, shutil
 from tqdm import tqdm
 import numpy as np
 from PIL import Image
 
-def rle_decoder(set_name, part_num): # converting rle data to JPG image
+def _to_jpeg_compatible(im: Image.Image) -> Image.Image:
+    """Return a JPEG-compatible PIL image (RGB or L). Flatten or convert as needed."""
+    if im.mode == "RGBA":
+        # Flatten alpha onto white background (change to (0,0,0) for black)
+        bg = Image.new("RGB", im.size, (255, 255, 255))
+        bg.paste(im, mask=im.split()[3])
+        return bg
+    if im.mode in ("P", "LA"):
+        return im.convert("RGB")
+    if im.mode not in ("RGB", "L"):
+        return im.convert("RGB")
+    return im
+
+def rle_decoder(set_name, part_num):  # converting rle data to JPG image
     print(' * Converting RLE data to JPG images')
-    txt_path = 'dataset/images/'+set_name+'/'+set_name+'-'+str(part_num)+'.txt'
-    image_folder = set_name+'-'+str(part_num)+'/'
-    if not os.path.exists(image_folder): os.mkdir(image_folder)
-    
-    with open(txt_path) as f:
+    txt_path = os.path.join('dataset', 'images', set_name, f'{set_name}-{part_num}.txt')
+    image_folder = f'{set_name}-{part_num}'
+    os.makedirs(image_folder, exist_ok=True)
+
+    with open(txt_path, 'r', encoding='utf-8') as f:
         txt_data = f.read()
         all_image_data = txt_data.split('\n')[:-1]
-    
-        for i in tqdm(all_image_data):
-            image_data = i[1:-1].split(',')
-            image_name, rle_data = image_data[0][1:-1], image_data[1][1:-1]
-            f = io.BytesIO()
-            f.write(base64.b64decode(rle_data))
-            image_arr = np.array(Image.open(f))
-            image = Image.fromarray(image_arr)
-            image.save(image_folder + '/' + image_name)
-    
-def cut_and_paste(set_name, part_num): # moving all files to one folder
-    print(' * Moving JPG images to '+set_name+' folder')
-    source = set_name+'-'+str(part_num)+'/'
-    destination = set_name+'/'
-    if not os.path.exists(destination):
-        os.makedirs(destination)
+
+        for line in tqdm(all_image_data):
+            try:
+                image_data = line[1:-1].split(',')
+                image_name, rle_data = image_data[0][1:-1], image_data[1][1:-1]
+
+                # decode bytes -> numpy -> PIL
+                bio = io.BytesIO()
+                bio.write(base64.b64decode(rle_data))
+                bio.seek(0)
+                image_arr = np.array(Image.open(bio))
+                image = Image.fromarray(image_arr)
+
+                # ensure JPEG-compatible
+                image = _to_jpeg_compatible(image)
+
+                out_path = os.path.join(image_folder, image_name)
+                image.save(out_path, format="JPEG")
+            except Exception as e:
+                print(f"[WARN] Failed to decode/save '{line[:64]}...': {e}")
+
+def cut_and_paste(set_name, part_num):  # moving all files to one folder
+    print(f' * Moving JPG images to {set_name} folder')
+    source = f'{set_name}-{part_num}'
+    destination = set_name
+    os.makedirs(destination, exist_ok=True)
 
     allfiles = os.listdir(source)
-    for f in tqdm(allfiles):
-        src_path = os.path.join(source, f)
-        dst_path = os.path.join(destination, f)
+    for fname in tqdm(allfiles):
+        src_path = os.path.join(source, fname)
+        dst_path = os.path.join(destination, fname)
         shutil.move(src_path, dst_path)
 
     os.rmdir(source)
-    
+
 if __name__ == '__main__':
     # To avoid OOM, please decode train, val & test set separately.
     dataset_dict = {sys.argv[1]: int(sys.argv[2])}
     for set_name in dataset_dict:
-        for part_num in range(dataset_dict[set_name]):
-            part_num = part_num + 1
-            print('\n decoding '+set_name+' set - part '+str(part_num))
+        for part_num in range(1, dataset_dict[set_name] + 1):
+            print(f'\n decoding {set_name} set - part {part_num}')
             rle_decoder(set_name, part_num)
-            cut_and_paste(set_name, part_num)  
+            cut_and_paste(set_name, part_num)


### PR DESCRIPTION
This PR fixes a bug in `CIS_decoder.py` that causes decoding to fail on some dataset parts (e.g., train6.txt) with the error:

> OSError: cannot write mode RGBA as JPEG


**Cause:**
Some frames in the CIS dataset decode to `RGBA `or `LA `mode, which cannot be directly saved as JPEG.

**Fix:**

- Added `_to_jpeg_compatible` function to safely convert/flatten unsupported modes (`RGBA`, `P`, `LA`) to RGB.
- Keeps JPEG outputs consistent with the existing pipeline.
- Added per-image error handling so decoding continues even if one file fails.

**Impact:**
Users can now decode all dataset parts without hitting the RGBA crash. This improves reproducibility and robustness for new users.